### PR TITLE
Update knex version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7648,12 +7648,12 @@
       }
     },
     "node_modules/knex": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-2.3.0.tgz",
-      "integrity": "sha512-WMizPaq9wRMkfnwKXKXgBZeZFOSHGdtoSz5SaLAVNs3WRDfawt9O89T4XyH52PETxjV8/kRk0Yf+8WBEP/zbYw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.5.1.tgz",
+      "integrity": "sha512-z78DgGKUr4SE/6cm7ku+jHvFT0X97aERh/f0MUKAKgFnwCYBEW4TFBqtHWFYiJFid7fMrtpZ/gxJthvz5mEByA==",
       "dependencies": {
         "colorette": "2.0.19",
-        "commander": "^9.1.0",
+        "commander": "^10.0.0",
         "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
@@ -7661,7 +7661,7 @@
         "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
-        "pg-connection-string": "2.5.0",
+        "pg-connection-string": "2.6.1",
         "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
         "tarn": "^3.0.2",
@@ -7698,11 +7698,11 @@
       }
     },
     "node_modules/knex/node_modules/commander": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "engines": {
-        "node": "^12.20.0 || >=14"
+        "node": ">=14"
       }
     },
     "node_modules/less": {
@@ -9285,9 +9285,9 @@
       }
     },
     "node_modules/pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
+      "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -18216,12 +18216,12 @@
       "dev": true
     },
     "knex": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-2.3.0.tgz",
-      "integrity": "sha512-WMizPaq9wRMkfnwKXKXgBZeZFOSHGdtoSz5SaLAVNs3WRDfawt9O89T4XyH52PETxjV8/kRk0Yf+8WBEP/zbYw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.5.1.tgz",
+      "integrity": "sha512-z78DgGKUr4SE/6cm7ku+jHvFT0X97aERh/f0MUKAKgFnwCYBEW4TFBqtHWFYiJFid7fMrtpZ/gxJthvz5mEByA==",
       "requires": {
         "colorette": "2.0.19",
-        "commander": "^9.1.0",
+        "commander": "^10.0.0",
         "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
@@ -18229,7 +18229,7 @@
         "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
-        "pg-connection-string": "2.5.0",
+        "pg-connection-string": "2.6.1",
         "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
         "tarn": "^3.0.2",
@@ -18237,9 +18237,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-          "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
         }
       }
     },
@@ -19427,9 +19427,9 @@
       "dev": true
     },
     "pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
+      "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg=="
     },
     "picocolors": {
       "version": "1.0.0",


### PR DESCRIPTION
There are a lot of changes and updates since knex version `2.3.0` that this was previously on.

I was specifically looking for `updateFrom` which was added in `2.5.0` and made me notice this was out of date.

I only tested very briefly with the query I was building at the time so may need more thorough testing but everything _seemed_ to work fine.